### PR TITLE
host overwrite

### DIFF
--- a/swagger_ui/core.py
+++ b/swagger_ui/core.py
@@ -78,7 +78,7 @@ class Interface(object):
         if StrictVersion(config.get('openapi', '2.0.0')) >= StrictVersion('3.0.0'):
             for server in config['servers']:
                 server['url'] = re.sub('//[a-z0-9\-\.:]+/?', '//{}/'.format(host), server['url'])
-        else:
+        elif not 'host' in config:
             config['host'] = host
         return config
 


### PR DESCRIPTION
The software is always overwriting the host declared in the config with the current host of the server.
This breaks the uris in swagger when used in Docker environment.

I add a further _if_ for avoiding it