### PR TITLE
Added support for bottle

### DIFF
--- a/swagger_ui/__init__.py
+++ b/swagger_ui/__init__.py
@@ -5,3 +5,4 @@ from .old import FlaskInterface as flask_api_doc
 from .old import QuartInterface as quart_api_doc
 from .old import SanicInterface as sanic_api_doc
 from .old import TornadoInterface as tornado_api_doc
+from .old import BottleInterface as bottle_api_doc

--- a/swagger_ui/old.py
+++ b/swagger_ui/old.py
@@ -41,3 +41,8 @@ class StarletteInterface(Interface):
     def __init__(self, *args, **kwargs):
         kwargs['app_type'] = 'starlette'
         super(StarletteInterface, self).__init__(*args, **kwargs)
+
+class BottleInterface(Interface):
+    def __init__(self, *args, **kwargs):
+        kwargs['app_type'] = 'bottle'
+        super(BottleInterface, self).__init__(*args, **kwargs)


### PR DESCRIPTION
The bottle server is a small WSGI capable server
that should not be missed here.
If it is running under WSGI-REF server built-in with
python 3.6, the redirect call should be used.

The rest of the implementation should be strait forward.