### PR TITLE
Add Cyclone support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Only support Python3.
 - starlette
 - falcon
 - bottle
+- cyclone
 
 ## Usage
 
@@ -65,14 +66,14 @@ Only support Python3.
   # for aiohttp
   from swagger_ui import aiohttp_api_doc
   aiohttp_api_doc(app, config_path='./conf/test.yaml', url_prefix='/api/doc', title='API doc')
-  
+
   # for Falcon
   from swagger_ui import falcon_api_doc
   falcon_api_doc(app, config_path='./conf/test.yaml', url_prefix='/api/doc', title='API doc')
   ```
 
 - Edit `Swagger` config file (JSON or YAML)
-  
+
   Please see [https://swagger.io/resources/open-api/](https://swagger.io/resources/open-api/).
 
 - Access


### PR DESCRIPTION
This PR adds Cyclone support. Cyclone implements the Tornado API, so their usage can be identical within this library.