### PR TITLE
Add partial support for initOAuth and add support for OAuth2 Implicit Flow to Falcon

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Only support Python3.
   api_doc(api, config_path='./config/test.yaml', url_prefix='/api/doc', title='API doc', initOAuth={"clientId": "client", "clientSecret": "client-secret"})
   ```
 
-  Enabling OAuth2 implicit flow redirect landing page (Only works for Falcon, not tested with url_prefix)
+  Enabling OAuth2 implicit flow redirect landing page
+  It only works for Falcon and it only works from root (url_prefix='/')
 
   ```python
   api_doc(app, config_path='./config/test.yaml', url_prefix='/', title='API doc', oauth2_implicit_flow=True)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ Only support Python3.
   api_doc(app, config_path='./config/test.yaml', url_prefix='/api/doc', title='API doc')
   ```
 
+  Using [initOAuth]https://swagger.io/docs/open-source-tools/swagger-ui/usage/oauth2/
+
+  ```python
+  api_doc(api, config_path='./config/test.yaml', url_prefix='/api/doc', title='API doc', initOAuth={"clientId": "client", "clientSecret": "client-secret"})
+  ```
+
+  Enabling OAuth2 implicit flow redirect landing page (Only works for Falcon, not tested with url_prefix)
+
+  ```python
+  api_doc(app, config_path='./config/test.yaml', url_prefix='/', title='API doc', oauth2_implicit_flow=True)
+  ```
+
   Using config url, but need to suport [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing)
 
   ```python

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def load_requirements():
 if __name__ == '__main__':
     setup(
         name='swagger-ui-py',
-        version='0.3.0',
+        version='0.3.1',
         description=DESCRIPTION,
         long_description=readme(),
         long_description_content_type='text/markdown',

--- a/swagger_ui/__init__.py
+++ b/swagger_ui/__init__.py
@@ -6,3 +6,5 @@ from .old import QuartInterface as quart_api_doc
 from .old import SanicInterface as sanic_api_doc
 from .old import TornadoInterface as tornado_api_doc
 from .old import BottleInterface as bottle_api_doc
+
+print("Jsi to ty, ale menší!")

--- a/swagger_ui/__init__.py
+++ b/swagger_ui/__init__.py
@@ -6,5 +6,3 @@ from .old import QuartInterface as quart_api_doc
 from .old import SanicInterface as sanic_api_doc
 from .old import TornadoInterface as tornado_api_doc
 from .old import BottleInterface as bottle_api_doc
-
-print("Jsi to ty, ale menší!")

--- a/swagger_ui/core.py
+++ b/swagger_ui/core.py
@@ -51,13 +51,13 @@ class Interface(object):
     @property
     def doc_html(self):
         return self._env.get_template('doc.html').render(
-            url_prefix=self._uri_with_prefix(), title=self._title, config_url=self._uri_with_prefix(), client_id=self._initOAuth["clientId"], client_secret=self._initOAuth["clientSecret"]
+            url_prefix=self._uri_with_prefix(), title=self._title, config_url=self._uri_with_prefix("swagger.json"), client_id=self._initOAuth["clientId"], client_secret=self._initOAuth["clientSecret"]
         )
 
     @property
     def editor_html(self):
         return self._env.get_template('editor.html').render(
-            url_prefix=self._uri_with_prefix(), title=self._title, config_url=self._uri_with_prefix()
+            url_prefix=self._uri_with_prefix(), title=self._title, config_url=self._uri_with_prefix("swagger.json")
         )
 
     @property

--- a/swagger_ui/core.py
+++ b/swagger_ui/core.py
@@ -12,12 +12,15 @@ CURRENT_DIR = Path(__file__).resolve().parent
 
 class Interface(object):
 
+    # url_prefix - relative path where UI is server
+    # url_prexix_rewrite - begining part of relative path, that is removed by proxy, but that is necessary for obtaining static files (.js, .css)
     def __init__(self, app, app_type=None, config_path=None, config_url=None,
-                 url_prefix='/api/doc', title='API doc', editor=False, initOAuth=None, oauth2_implicit_flow=False):
+                 url_prefix='/api/doc', url_prefix_rewrite='', title='API doc', editor=False, initOAuth=None, oauth2_implicit_flow=False):
 
         self._app = app
         self._title = title
         self._url_prefix = url_prefix.rstrip('/')
+        self._url_prefix_rewrite = url_prefix_rewrite.rstrip('/')
         self._config_url = config_url
         self._config_path = config_path
         self._editor = editor
@@ -48,13 +51,13 @@ class Interface(object):
     @property
     def doc_html(self):
         return self._env.get_template('doc.html').render(
-            url_prefix=self._url_prefix, title=self._title, config_url=self._uri('/swagger.json'), client_id=self._initOAuth["clientId"], client_secret=self._initOAuth["clientSecret"]
+            url_prefix=self._uri(), title=self._title, config_url=self._uri('/swagger.json'), client_id=self._initOAuth["clientId"], client_secret=self._initOAuth["clientSecret"]
         )
 
     @property
     def editor_html(self):
         return self._env.get_template('editor.html').render(
-            url_prefix=self._url_prefix, title=self._title, config_url=self._uri('/swagger.json')
+            url_prefix=self._uri(), title=self._title, config_url=self._uri('/swagger.json')
         )
 
     @property
@@ -93,7 +96,7 @@ class Interface(object):
         return config
 
     def _uri(self, suffix=''):
-        return r'{}{}'.format(self._url_prefix, suffix)
+        return r'{}{}{}'.format(self._url_prefix_rewrite,self._url_prefix, suffix)
 
     def _tornado_handler(self):
         from tornado.web import RequestHandler, StaticFileHandler

--- a/swagger_ui/core.py
+++ b/swagger_ui/core.py
@@ -51,13 +51,13 @@ class Interface(object):
     @property
     def doc_html(self):
         return self._env.get_template('doc.html').render(
-            url_prefix=self._uri_with_prefix(), title=self._title, config_url=self._uri_with_prefix("/swagger.json"), client_id=self._initOAuth["clientId"], client_secret=self._initOAuth["clientSecret"]
+            url_prefix=self._uri_with_prefix(), title=self._title, config_url=''.join((self._uri(), '/swagger.json')), client_id=self._initOAuth["clientId"], client_secret=self._initOAuth["clientSecret"]
         )
 
     @property
     def editor_html(self):
         return self._env.get_template('editor.html').render(
-            url_prefix=self._uri_with_prefix(), title=self._title, config_url=self._uri_with_prefix("/swagger.json")
+            url_prefix=self._uri_with_prefix(), title=self._title, config_url='/'.join((self._uri(), '/swagger.json'))
         )
 
     @property

--- a/swagger_ui/core.py
+++ b/swagger_ui/core.py
@@ -51,13 +51,13 @@ class Interface(object):
     @property
     def doc_html(self):
         return self._env.get_template('doc.html').render(
-            url_prefix=self._uri_with_prefix(), title=self._title, config_url=self._uri_with_prefix("swagger.json"), client_id=self._initOAuth["clientId"], client_secret=self._initOAuth["clientSecret"]
+            url_prefix=self._uri_with_prefix(), title=self._title, config_url=self._uri_with_prefix("/swagger.json"), client_id=self._initOAuth["clientId"], client_secret=self._initOAuth["clientSecret"]
         )
 
     @property
     def editor_html(self):
         return self._env.get_template('editor.html').render(
-            url_prefix=self._uri_with_prefix(), title=self._title, config_url=self._uri_with_prefix("swagger.json")
+            url_prefix=self._uri_with_prefix(), title=self._title, config_url=self._uri_with_prefix("/swagger.json")
         )
 
     @property

--- a/swagger_ui/core.py
+++ b/swagger_ui/core.py
@@ -51,13 +51,13 @@ class Interface(object):
     @property
     def doc_html(self):
         return self._env.get_template('doc.html').render(
-            url_prefix=self._uri(), title=self._title, config_url=self._uri('/swagger.json'), client_id=self._initOAuth["clientId"], client_secret=self._initOAuth["clientSecret"]
+            url_prefix=self._uri_with_prefix(), title=self._title, config_url=self._uri_with_prefix('/swagger.json'), client_id=self._initOAuth["clientId"], client_secret=self._initOAuth["clientSecret"]
         )
 
     @property
     def editor_html(self):
         return self._env.get_template('editor.html').render(
-            url_prefix=self._uri(), title=self._title, config_url=self._uri('/swagger.json')
+            url_prefix=self._uri_with_prefix(), title=self._title, config_url=self._uri_with_prefix('/swagger.json')
         )
 
     @property
@@ -95,8 +95,11 @@ class Interface(object):
             config['host'] = host
         return config
 
-    def _uri(self, suffix=''):
+    def _uri_with_prefix(self, suffix=''):
         return r'{}{}{}'.format(self._url_prefix_rewrite,self._url_prefix, suffix)
+
+    def _uri(self, suffix=''):
+        return r'{}{}'.format(self._url_prefix, suffix)
 
     def _tornado_handler(self):
         from tornado.web import RequestHandler, StaticFileHandler

--- a/swagger_ui/core.py
+++ b/swagger_ui/core.py
@@ -51,13 +51,13 @@ class Interface(object):
     @property
     def doc_html(self):
         return self._env.get_template('doc.html').render(
-            url_prefix=self._uri_with_prefix(), title=self._title, config_url=''.join((self._uri(), '/swagger.json')), client_id=self._initOAuth["clientId"], client_secret=self._initOAuth["clientSecret"]
+            url_prefix=self._uri_with_prefix(), title=self._title, config_url=''.join((self._uri_with_prefix(), '/swagger.json')), client_id=self._initOAuth["clientId"], client_secret=self._initOAuth["clientSecret"]
         )
 
     @property
     def editor_html(self):
         return self._env.get_template('editor.html').render(
-            url_prefix=self._uri_with_prefix(), title=self._title, config_url='/'.join((self._uri(), '/swagger.json'))
+            url_prefix=self._uri_with_prefix(), title=self._title, config_url='/'.join((self._uri_with_prefix(), '/swagger.json'))
         )
 
     @property

--- a/swagger_ui/core.py
+++ b/swagger_ui/core.py
@@ -51,13 +51,13 @@ class Interface(object):
     @property
     def doc_html(self):
         return self._env.get_template('doc.html').render(
-            url_prefix=self._uri_with_prefix(), title=self._title, config_url=self._uri_with_prefix('/swagger.json'), client_id=self._initOAuth["clientId"], client_secret=self._initOAuth["clientSecret"]
+            url_prefix=self._uri_with_prefix(), title=self._title, config_url=self._uri('/swagger.json'), client_id=self._initOAuth["clientId"], client_secret=self._initOAuth["clientSecret"]
         )
 
     @property
     def editor_html(self):
         return self._env.get_template('editor.html').render(
-            url_prefix=self._uri_with_prefix(), title=self._title, config_url=self._uri_with_prefix('/swagger.json')
+            url_prefix=self._uri_with_prefix(), title=self._title, config_url=self._uri('/swagger.json')
         )
 
     @property

--- a/swagger_ui/core.py
+++ b/swagger_ui/core.py
@@ -51,13 +51,13 @@ class Interface(object):
     @property
     def doc_html(self):
         return self._env.get_template('doc.html').render(
-            url_prefix=self._uri_with_prefix(), title=self._title, config_url=self._uri('/swagger.json'), client_id=self._initOAuth["clientId"], client_secret=self._initOAuth["clientSecret"]
+            url_prefix=self._uri_with_prefix(), title=self._title, config_url='/'.join((self._uri(), 'swagger.json')), client_id=self._initOAuth["clientId"], client_secret=self._initOAuth["clientSecret"]
         )
 
     @property
     def editor_html(self):
         return self._env.get_template('editor.html').render(
-            url_prefix=self._uri_with_prefix(), title=self._title, config_url=self._uri('/swagger.json')
+            url_prefix=self._uri_with_prefix(), title=self._title, config_url='/'.join((self._uri(), 'swagger.json'))
         )
 
     @property

--- a/swagger_ui/core.py
+++ b/swagger_ui/core.py
@@ -254,7 +254,7 @@ class Interface(object):
                 resp.content_type = 'text/html'
                 resp.body = interface.editor_html
 
-        class SwaggerOauth2RedirectHandler:
+        class SwaggerOAuth2RedirectHandler:
             def on_get(self, req, resp):
                 resp.content_type = 'text/html'
                 resp.body = interface.oauth2_redirect_html
@@ -270,7 +270,7 @@ class Interface(object):
             self._app.add_route(self._uri('/editor'), SwaggerEditorHandler())
 
         if self._oauth2_implicit_flow:
-            self._app.add_route(self._uri('/oauth2-redirect.html'), SwaggerOauth2RedirectHandler())
+            self._app.add_route(self._uri('/oauth2-redirect.html'), SwaggerOAuth2RedirectHandler())
 
         self._app.add_route(self._uri('/swagger.json'), SwaggerConfigHandler())
         self._app.add_static_route(prefix=self._uri(

--- a/swagger_ui/core.py
+++ b/swagger_ui/core.py
@@ -27,7 +27,7 @@ class Interface(object):
         if initOAuth:
             self._initOAuth["clientId"] = initOAuth["clientId"]
             self._initOAuth["clientSecret"] = initOAuth["clientSecret"]
-	self._oauth2_implicit_flow = oauth2_implicit_flow
+        self._oauth2_implicit_flow = oauth2_implicit_flow
 
         assert self._config_url or self._config_path, 'config_url or config_path is required!'
 

--- a/swagger_ui/core.py
+++ b/swagger_ui/core.py
@@ -13,7 +13,7 @@ CURRENT_DIR = Path(__file__).resolve().parent
 class Interface(object):
 
     def __init__(self, app, app_type=None, config_path=None, config_url=None,
-                 url_prefix='/api/doc', title='API doc', editor=False):
+                 url_prefix='/api/doc', title='API doc', editor=False, initOAuth=None):
 
         self._app = app
         self._title = title
@@ -21,6 +21,12 @@ class Interface(object):
         self._config_url = config_url
         self._config_path = config_path
         self._editor = editor
+        self._initOAuth = {}
+        self._initOAuth["clientId"] = None
+        self._initOAuth["clientSecret"] = None
+        if initOAuth:
+            self._initOAuth["clientId"] = initOAuth["clientId"]
+            self._initOAuth["clientSecret"] = initOAuth["clientSecret"]
 
         assert self._config_url or self._config_path, 'config_url or config_path is required!'
 
@@ -41,7 +47,7 @@ class Interface(object):
     @property
     def doc_html(self):
         return self._env.get_template('doc.html').render(
-            url_prefix=self._url_prefix, title=self._title, config_url=self._uri('/swagger.json')
+            url_prefix=self._url_prefix, title=self._title, config_url=self._uri('/swagger.json'), client_id=self._initOAuth["clientId"], client_secret=self._initOAuth["clientSecret"]
         )
 
     @property

--- a/swagger_ui/core.py
+++ b/swagger_ui/core.py
@@ -51,13 +51,13 @@ class Interface(object):
     @property
     def doc_html(self):
         return self._env.get_template('doc.html').render(
-            url_prefix=self._uri_with_prefix(), title=self._title, config_url='/'.join((self._uri(), 'swagger.json')), client_id=self._initOAuth["clientId"], client_secret=self._initOAuth["clientSecret"]
+            url_prefix=self._uri_with_prefix(), title=self._title, config_url=self._uri_with_prefix(), client_id=self._initOAuth["clientId"], client_secret=self._initOAuth["clientSecret"]
         )
 
     @property
     def editor_html(self):
         return self._env.get_template('editor.html').render(
-            url_prefix=self._uri_with_prefix(), title=self._title, config_url='/'.join((self._uri(), 'swagger.json'))
+            url_prefix=self._uri_with_prefix(), title=self._title, config_url=self._uri_with_prefix()
         )
 
     @property

--- a/swagger_ui/templates/doc.html
+++ b/swagger_ui/templates/doc.html
@@ -53,6 +53,11 @@
       })
       // End Swagger UI call region
 
+      ui.initOAuth({
+        clientId: "{{ client_id }}",
+        clientSecret: "{{ client_secret }}"
+      })
+
       window.ui = ui
     }
   </script>

--- a/swagger_ui/templates/oauth2-redirect.html
+++ b/swagger_ui/templates/oauth2-redirect.html
@@ -1,66 +1,67 @@
-<!-- HTML for static distribution bundle build -->
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <title> {{ title }} </title>
-    <link rel="stylesheet" type="text/css" href="{{ url_prefix }}/swagger-ui.css" >
-    <link rel="icon" type="image/png" href="{{ url_prefix }}/favicon-32x32.png" sizes="32x32" />
-    <link rel="icon" type="image/png" href="{{ url_prefix }}/favicon-16x16.png" sizes="16x16" />
-    <style>
-      html
-      {
-        box-sizing: border-box;
-        overflow: -moz-scrollbars-vertical;
-        overflow-y: scroll;
-      }
-
-      *,
-      *:before,
-      *:after
-      {
-        box-sizing: inherit;
-      }
-
-      body
-      {
-        margin:0;
-        background: #fafafa;
-      }
-    </style>
-  </head>
-
-  <body>
-    <div id="swagger-ui"></div>
-
-    <script src="{{ url_prefix }}/swagger-ui-bundle.js"> </script>
-    <script src="{{ url_prefix }}/swagger-ui-standalone-preset.js"> </script>
-    <script>
-    window.onload = function() {
-      // Begin Swagger UI call region
-      const ui = SwaggerUIBundle({
-        url: "{{ config_url }}",
-        dom_id: '#swagger-ui',
-        deepLinking: true,
-        presets: [
-          SwaggerUIBundle.presets.apis,
-          SwaggerUIStandalonePreset
-        ],
-        plugins: [
-          SwaggerUIBundle.plugins.DownloadUrl
-        ],
-        layout: "StandaloneLayout"
-      })
-      // End Swagger UI call region
-
-      ui.initOAuth({
-        clientId: "{{ client_id }}",
-        clientSecret: "{{ client_secret }}"
-      })
-
-      window.ui = ui
-    }
-  </script>
-  </body>
+<!doctype html>
+<html lang="en-US">
+<body onload="run()">
+</body>
 </html>
+<script>
+    'use strict';
+    function run () {
+        var oauth2 = window.opener.swaggerUIRedirectOauth2;
+        var sentState = oauth2.state;
+        var redirectUrl = oauth2.redirectUrl;
+        var isValid, qp, arr;
 
+        if (/code|token|error/.test(window.location.hash)) {
+            qp = window.location.hash.substring(1);
+        } else {
+            qp = location.search.substring(1);
+        }
+
+        arr = qp.split("&")
+        arr.forEach(function (v,i,_arr) { _arr[i] = '"' + v.replace('=', '":"') + '"';})
+        qp = qp ? JSON.parse('{' + arr.join() + '}',
+                function (key, value) {
+                    return key === "" ? value : decodeURIComponent(value)
+                }
+        ) : {}
+
+        isValid = qp.state === sentState
+
+        if ((
+          oauth2.auth.schema.get("flow") === "accessCode"||
+          oauth2.auth.schema.get("flow") === "authorizationCode"
+        ) && !oauth2.auth.code) {
+            if (!isValid) {
+                oauth2.errCb({
+                    authId: oauth2.auth.name,
+                    source: "auth",
+                    level: "warning",
+                    message: "Authorization may be unsafe, passed state was changed in server Passed state wasn't returned from auth server"
+                });
+            }
+
+            if (qp.code) {
+                delete oauth2.state;
+                oauth2.auth.code = qp.code;
+                oauth2.callback({auth: oauth2.auth, redirectUrl: redirectUrl});
+            } else {
+                let oauthErrorMsg
+                if (qp.error) {
+                    oauthErrorMsg = "["+qp.error+"]: " +
+                        (qp.error_description ? qp.error_description+ ". " : "no accessCode received from the server. ") +
+                        (qp.error_uri ? "More info: "+qp.error_uri : "");
+                }
+
+                oauth2.errCb({
+                    authId: oauth2.auth.name,
+                    source: "auth",
+                    level: "error",
+                    message: oauthErrorMsg || "[Authorization failed]: no accessCode received from the server"
+                });
+            }
+        } else {
+            oauth2.callback({auth: oauth2.auth, token: qp, isValid: isValid, redirectUrl: redirectUrl});
+        }
+        window.close();
+    }
+</script>

--- a/swagger_ui/templates/oauth2-redirect.html
+++ b/swagger_ui/templates/oauth2-redirect.html
@@ -1,67 +1,66 @@
-<!doctype html>
-<html lang="en-US">
-<body onload="run()">
-</body>
-</html>
-<script>
-    'use strict';
-    function run () {
-        var oauth2 = window.opener.swaggerUIRedirectOauth2;
-        var sentState = oauth2.state;
-        var redirectUrl = oauth2.redirectUrl;
-        var isValid, qp, arr;
+<!-- HTML for static distribution bundle build -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title> {{ title }} </title>
+    <link rel="stylesheet" type="text/css" href="{{ url_prefix }}/swagger-ui.css" >
+    <link rel="icon" type="image/png" href="{{ url_prefix }}/favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="{{ url_prefix }}/favicon-16x16.png" sizes="16x16" />
+    <style>
+      html
+      {
+        box-sizing: border-box;
+        overflow: -moz-scrollbars-vertical;
+        overflow-y: scroll;
+      }
 
-        if (/code|token|error/.test(window.location.hash)) {
-            qp = window.location.hash.substring(1);
-        } else {
-            qp = location.search.substring(1);
-        }
+      *,
+      *:before,
+      *:after
+      {
+        box-sizing: inherit;
+      }
 
-        arr = qp.split("&")
-        arr.forEach(function (v,i,_arr) { _arr[i] = '"' + v.replace('=', '":"') + '"';})
-        qp = qp ? JSON.parse('{' + arr.join() + '}',
-                function (key, value) {
-                    return key === "" ? value : decodeURIComponent(value)
-                }
-        ) : {}
+      body
+      {
+        margin:0;
+        background: #fafafa;
+      }
+    </style>
+  </head>
 
-        isValid = qp.state === sentState
+  <body>
+    <div id="swagger-ui"></div>
 
-        if ((
-          oauth2.auth.schema.get("flow") === "accessCode"||
-          oauth2.auth.schema.get("flow") === "authorizationCode"
-        ) && !oauth2.auth.code) {
-            if (!isValid) {
-                oauth2.errCb({
-                    authId: oauth2.auth.name,
-                    source: "auth",
-                    level: "warning",
-                    message: "Authorization may be unsafe, passed state was changed in server Passed state wasn't returned from auth server"
-                });
-            }
+    <script src="{{ url_prefix }}/swagger-ui-bundle.js"> </script>
+    <script src="{{ url_prefix }}/swagger-ui-standalone-preset.js"> </script>
+    <script>
+    window.onload = function() {
+      // Begin Swagger UI call region
+      const ui = SwaggerUIBundle({
+        url: "{{ config_url }}",
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIStandalonePreset
+        ],
+        plugins: [
+          SwaggerUIBundle.plugins.DownloadUrl
+        ],
+        layout: "StandaloneLayout"
+      })
+      // End Swagger UI call region
 
-            if (qp.code) {
-                delete oauth2.state;
-                oauth2.auth.code = qp.code;
-                oauth2.callback({auth: oauth2.auth, redirectUrl: redirectUrl});
-            } else {
-                let oauthErrorMsg
-                if (qp.error) {
-                    oauthErrorMsg = "["+qp.error+"]: " +
-                        (qp.error_description ? qp.error_description+ ". " : "no accessCode received from the server. ") +
-                        (qp.error_uri ? "More info: "+qp.error_uri : "");
-                }
+      ui.initOAuth({
+        clientId: "{{ client_id }}",
+        clientSecret: "{{ client_secret }}"
+      })
 
-                oauth2.errCb({
-                    authId: oauth2.auth.name,
-                    source: "auth",
-                    level: "error",
-                    message: oauthErrorMsg || "[Authorization failed]: no accessCode received from the server"
-                });
-            }
-        } else {
-            oauth2.callback({auth: oauth2.auth, token: qp, isValid: isValid, redirectUrl: redirectUrl});
-        }
-        window.close();
+      window.ui = ui
     }
-</script>
+  </script>
+  </body>
+</html>
+


### PR DESCRIPTION
Hi, this is a great library. However, it could be enhanced by supporting initOAuth Javascript method, which allows to prefill some OAuth2 configurations, which, please correct me if I am wrong, cannot be saved directly into the api specification. Namely client-id and client-secret. https://swagger.io/docs/open-source-tools/swagger-ui/usage/oauth2/
Also, I was unable to expose the redirect page for OAuth2 Implicit Flow (oauth2-redirect.html), please advise if there is already a way to do that. If there is not, my proposed solution has many drawbacks, I only implemented it for Falcon framework and it only works if the prefix url is "/". And I cannot seem to figure out, how to configure custom redirection url to the swagger ui.

For a little bit of context, I am using Keycloak as an identity provider and I am generating the swagger documentation with APISpec where I use following code to define the security and it is working fine for me with the proposed changes.
`    OPENAPI_SPEC = """
    # Apply security globally
    security: 
      - jwt_password: 
      - jwt_implicit:
    """
    settings = yaml.safe_load(OPENAPI_SPEC)
    spec = APISpec(
        title='API',
        version='0.0.0',
        openapi_version='2.0',
        description="Documentation",
        plugins=[
            FalconPlugin(falcon_app),
            MarshmallowPlugin(),
        ],
        **settings
    )

    jwt_password_scheme = {
        "type": "oauth2",
        "flow": "password",
        "tokenUrl": "http://10.0.0.1:30000/auth/realms/master/protocol/openid-connect/token",
        "scopes": {}
    }
    spec.components.security_scheme("jwt_password", jwt_password_scheme)

    jwt_implicit_scheme = {
        "type": "oauth2",
        "flow": "implicit",
        "authorizationUrl": "http://10.0.0.1:30000/auth/realms/master/protocol/openid-connect/auth",
        "scopes": {}
    }
    spec.components.security_scheme("jwt_implicit", jwt_implicit_scheme)`