### PR TITLE
Feature/customizable UI config

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Only support Python3.
   api_doc(app, config_url='https://petstore.swagger.io/v2/swagger.json', url_prefix='/api/doc', title='API doc')
   ```
 
+  Setting addtional [SwaggerUI configuration parameters](https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/) (simple values only, functions and variables are not supported)
+
+  ```python
+  api_doc(app, config_path='/config/test.yaml', title='API doc', doc_config={ "validationUrl": None })
+  ```
+
   And suport config file editor
 
   ```python

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def load_requirements():
 if __name__ == '__main__':
     setup(
         name='swagger-ui-py',
-        version='0.3.0',
+        version='0.4.0-dev',
         description=DESCRIPTION,
         long_description=readme(),
         long_description_content_type='text/markdown',

--- a/swagger_ui/core.py
+++ b/swagger_ui/core.py
@@ -13,7 +13,8 @@ CURRENT_DIR = Path(__file__).resolve().parent
 class Interface(object):
 
     def __init__(self, app, app_type=None, config_path=None, config_url=None,
-                 url_prefix='/api/doc', title='API doc', editor=False):
+                 url_prefix='/api/doc', title='API doc', editor=False,
+                 doc_config=None):
 
         self._app = app
         self._title = title
@@ -21,6 +22,7 @@ class Interface(object):
         self._config_url = config_url
         self._config_path = config_path
         self._editor = editor
+        self._doc_config = doc_config
 
         assert self._config_url or self._config_path, 'config_url or config_path is required!'
 
@@ -41,7 +43,10 @@ class Interface(object):
     @property
     def doc_html(self):
         return self._env.get_template('doc.html').render(
-            url_prefix=self._url_prefix, title=self._title, config_url=self._uri('/swagger.json')
+            url_prefix=self._url_prefix,
+            title=self._title,
+            config_url=self._uri('/swagger.json'),
+            doc_config_json=json.dumps(self._doc_config)
         )
 
     @property

--- a/swagger_ui/templates/doc.html
+++ b/swagger_ui/templates/doc.html
@@ -4,7 +4,7 @@
   <head>
     <meta charset="UTF-8">
     <title> {{ title }} </title>
-    <link rel="stylesheet" type="text/css" href="{{ url_prefix }}/swagger-ui.css" >
+    <link rel="stylesheet" type="text/css" href="{{ url_prefix }}/swagger-ui.css" />
     <link rel="icon" type="image/png" href="{{ url_prefix }}/favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="{{ url_prefix }}/favicon-16x16.png" sizes="16x16" />
     <style>
@@ -33,8 +33,8 @@
   <body>
     <div id="swagger-ui"></div>
 
-    <script src="{{ url_prefix }}/swagger-ui-bundle.js"> </script>
-    <script src="{{ url_prefix }}/swagger-ui-standalone-preset.js"> </script>
+    <script src="{{ url_prefix }}/swagger-ui-bundle.js" charset="UTF-8"> </script>
+    <script src="{{ url_prefix }}/swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
     <script>
     window.onload = function() {
       // Begin Swagger UI call region
@@ -49,12 +49,12 @@
         plugins: [
           SwaggerUIBundle.plugins.DownloadUrl
         ],
-        layout: "StandaloneLayout"
-      })
+        layout: "StandaloneLayout", <% if config_json != "null" %>...{{ config_json | safe }}<% endif %>
+      });
       // End Swagger UI call region
 
-      window.ui = ui
-    }
+      window.ui = ui;
+    };
   </script>
   </body>
 </html>

--- a/tools/update.py
+++ b/tools/update.py
@@ -79,6 +79,7 @@ def replace_html_content():
         index_content = re.sub('href="\\.', 'href="{{ url_prefix }}', index_content)
         index_content = re.sub('https://petstore.swagger.io/v[1-9]/swagger.json',
                                '{{ config_url }}', index_content)
+        index_content = re.sub('layout: "StandaloneLayout"', 'layout: "StandaloneLayout", <% if config_json != "null" %>...{{ config_json | safe }}<% endif %>', index_content)
 
         with html_path.open('w') as html_file:
             html_file.write(index_content)


### PR DESCRIPTION
There are many options in the swagger ui configuration that can't currently be set. This update allows setting most parameters  that are listed in the [SwaggerUI configuration documentation](https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/) (simple values only, no functions or variable values)

This would allow for handling scenarios reported in issues #9 and #18 like this:

```python
swagger_doc_config = { "validationUrl": None, "displayRequestDuration": True }

api_doc(app, config_path='/config/test.yaml', title='API doc', doc_config=swagger_doc_config)
```