### PR TITLE
Adding support to pass JSON/YAML string as spec to render SwaggerUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ Only support Python3.
   ```python
   api_doc(app, config_path='./config/test.yaml', editor=True)
   ```
+  Using the local variable
+  
+    ```python
+    from swagger_ui import api_doc
+    spec_string = '{"paths": {"/random": {"get": {"description": "Get a random pet", "security": [{"ApiKeyAuth": []}], "responses": {"200": {"description": "Return a pet", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Pet"}}}}}}}}, "info": {"title": "Swagger Petstore", "version": "1.0.0"}, "openapi": "3.0.2", "components": {"schemas": {"Category": {"type": "object", "properties": {"id": {"type": "integer"}, "name": {"type": "string"}}, "required": ["name"]}, "Pet": {"type": "object", "properties": {"categories": {"type": "array", "items": {"$ref": "#/components/schemas/Category"}}, "name": {"type": "string"}}}}, "securitySchemes": {"ApiKeyAuth": {"type": "apiKey", "in": "header", "name": "X-API-Key"}}}}'
+
+
+    api_doc(app, config_path='./config/test.yaml', url_prefix='/api/doc', title='API doc')
+    ```
 
   And keep the old way
 

--- a/examples/tornado_test_2.py
+++ b/examples/tornado_test_2.py
@@ -1,0 +1,36 @@
+import json
+import os
+
+import tornado.ioloop
+import tornado.web
+
+
+class HelloWorldHandler(tornado.web.RequestHandler):
+    def get(self, *args, **kwargs):
+        return self.write('Hello World!!!')
+
+
+def make_app():
+    return tornado.web.Application([
+        (r'/hello/world', HelloWorldHandler),
+    ])
+
+
+if __name__ == '__main__':
+    app = make_app()
+
+    from swagger_ui import api_doc
+    spec_string = '{"paths": {"/random": {"get": {"description": "Get a random pet", "security": [{"ApiKeyAuth": []}],' \
+                  ' "responses": {"200": {"description": "Return a pet", "content": {"application/json":' \
+                  ' {"schema": {"$ref": "#/components/schemas/Pet"}}}}}}}}, ' \
+                  '"info": {"title": "Swagger Petstore", "version": "1.0.0"},' \
+                  ' "openapi": "3.0.0", "servers" : [ {"url": "http://127.0.0.1:8989/api"}],' \
+                  ' "components": {"schemas": {"Category": {"type": "object", "properties": ' \
+                  '{"id": {"type": "integer"}, "name": {"type": "string"}}, "required": ["name"]}, "Pet": ' \
+                  '{"type": "object", "properties": {"categories": {"type": "array", "items": ' \
+                  '{"$ref": "#/components/schemas/Category"}}, "name": {"type": "string"}}}}, "securitySchemes": ' \
+                  '{"ApiKeyAuth": {"type": "apiKey", "in": "header", "name": "X-API-Key"}}}}'
+    api_doc(app, spec=spec_string, url_prefix='/api/doc/')
+
+    app.listen(8989)
+    tornado.ioloop.IOLoop.current().start()

--- a/swagger_ui/core.py
+++ b/swagger_ui/core.py
@@ -12,7 +12,7 @@ CURRENT_DIR = Path(__file__).resolve().parent
 
 class Interface(object):
 
-    def __init__(self, app, app_type=None, config_path=None, config_url=None,
+    def __init__(self, app, app_type=None, config_path=None, config_url=None, spec=None,
                  url_prefix='/api/doc', title='API doc', editor=False):
 
         self._app = app
@@ -21,8 +21,9 @@ class Interface(object):
         self._config_url = config_url
         self._config_path = config_path
         self._editor = editor
+        self._spec = spec
 
-        assert self._config_url or self._config_path, 'config_url or config_path is required!'
+        assert self._config_url or self._config_path or self._spec, 'config_url or config_path is required!'
 
         self._env = Environment(
             loader=FileSystemLoader(str(CURRENT_DIR.joinpath('templates'))),
@@ -73,7 +74,8 @@ class Interface(object):
         elif self._config_url:
             with urllib.request.urlopen(self._config_url) as config_file:
                 config = self._load_config(config_file.read())
-
+        elif self._spec:
+            config = self._load_config(self._spec)
         if StrictVersion(config.get('openapi', '2.0.0')) >= StrictVersion('3.0.0'):
             for server in config['servers']:
                 server['url'] = re.sub(r'//[a-z0-9\-\.:]+/?', '//{}/'.format(host), server['url'])


### PR DESCRIPTION
Added ability to pass API spec to pass as a string via spec field to api_doc. This was swagger-UI-py can be used in connection with libraries like apices 

`spec_string = '{"paths": {"/random": {"get": {"description": "Get a random pet", "security": [{"ApiKeyAuth": []}],' \
                  ' "responses": {"200": {"description": "Return a pet", "content": {"application/json":' \
                  ' {"schema": {"$ref": "#/components/schemas/Pet"}}}}}}}}, ' \
                  '"info": {"title": "Swagger Petstore", "version": "1.0.0"},' \
                  ' "openapi": "3.0.0", "servers" : [ {"url": "http://127.0.0.1:8989/api"}],' \
                  ' "components": {"schemas": {"Category": {"type": "object", "properties": ' \
                  '{"id": {"type": "integer"}, "name": {"type": "string"}}, "required": ["name"]}, "Pet": ' \
                  '{"type": "object", "properties": {"categories": {"type": "array", "items": ' \
                  '{"$ref": "#/components/schemas/Category"}}, "name": {"type": "string"}}}}, "securitySchemes": ' \
                  '{"ApiKeyAuth": {"type": "apiKey", "in": "header", "name": "X-API-Key"}}}}'
    api_doc(app, spec=spec_string, url_prefix='/api/doc/')`