### PR TITLE
feat: added config_rel_url parameter

### DIFF
--- a/swagger_ui/core.py
+++ b/swagger_ui/core.py
@@ -30,6 +30,7 @@ class ApplicationDocument(object):
                  config_path=None,
                  config_url=None,
                  config_spec=None,
+                 config_rel_url=None,
                  url_prefix=r'/api/doc',
                  title='API doc',
                  editor=False,
@@ -47,8 +48,10 @@ class ApplicationDocument(object):
         self.config_url = config_url
         self.config_path = config_path
         self.config_spec = config_spec
-        assert self.config or self.config_url or self.config_path or self.config_spec, \
-            'One of arguments "config", "config_path", "config_url" or "config_spec" is required!'
+        self.config_rel_url = config_rel_url
+        assert self.config or self.config_url or self.config_path or self.config_spec or self.config_rel_url, \
+            'One of arguments "config", "config_path", "config_url", "config_spec" or "config_rel_url" is required!'
+
 
         # parameters
         self.parameters = copy.deepcopy(_DefaultSwaggerUIBundleParameters)
@@ -105,7 +108,7 @@ class ApplicationDocument(object):
 
     @property
     def swagger_json_uri_relative(self):
-        return r'/swagger.json'
+        return self.config_rel_url or r'/swagger.json'
 
     @property
     def swagger_json_uri_absolute(self):

--- a/swagger_ui/handlers/aiohttp.py
+++ b/swagger_ui/handlers/aiohttp.py
@@ -21,8 +21,9 @@ def handler(doc):
         doc.app.router.add_get(
             doc.editor_uri_absolute(slashes=False), swagger_editor_handler)
 
-    doc.app.router.add_get(
-        doc.swagger_json_uri_absolute, swagger_config_handler)
+    if doc.config_rel_url is None:
+        doc.app.router.add_get(
+            doc.swagger_json_uri_absolute, swagger_config_handler)
     doc.app.router.add_static(doc.static_uri_absolute, path=doc.static_dir)
 
 

--- a/swagger_ui/handlers/bottle.py
+++ b/swagger_ui/handlers/bottle.py
@@ -6,9 +6,10 @@ def handler(doc):
     def index():
         return doc.doc_html
 
-    @doc.app.get(doc.swagger_json_uri_absolute)
-    def config_handler():
-        return doc.get_config(request.urlparts.netloc)
+    if doc.config_rel_url is None:
+        @doc.app.get(doc.swagger_json_uri_absolute)
+        def config_handler():
+            return doc.get_config(request.urlparts.netloc)
 
     @doc.app.get(r'{}/<filepath>'.format(doc.static_uri_absolute))
     def java_script_file(filepath):

--- a/swagger_ui/handlers/chalice.py
+++ b/swagger_ui/handlers/chalice.py
@@ -15,10 +15,11 @@ def handler(doc):
             headers={"Content-Type": "text/html"},
         )
 
-    @bp.route(doc.swagger_json_uri_relative, methods=["GET"])
-    def bp_config_handler():
-        request = doc.app.current_request
-        return doc.get_config(request.headers["host"])
+    if doc.config_rel_url is None:
+        @bp.route(doc.swagger_json_uri_relative, methods=["GET"])
+        def bp_config_handler():
+            request = doc.app.current_request
+            return doc.get_config(request.headers["host"])
 
     if doc.editor:
         @bp.route(doc.editor_uri_relative(slashes=True), methods=["GET"])

--- a/swagger_ui/handlers/falcon.py
+++ b/swagger_ui/handlers/falcon.py
@@ -38,8 +38,9 @@ class FalconInterface(object):
             doc.app.add_route(doc.editor_uri_absolute(slashes=False),
                               SwaggerEditorHandler(), suffix=suffix)
 
-        doc.app.add_route(doc.swagger_json_uri_absolute,
-                          SwaggerConfigHandler(), suffix=suffix)
+        if doc.config_rel_url is None:
+            doc.app.add_route(doc.swagger_json_uri_absolute,
+                            SwaggerConfigHandler(), suffix=suffix)
         doc.app.add_static_route(
             prefix=doc.static_uri_absolute,
             directory='{}/'.format(doc.static_dir),

--- a/swagger_ui/handlers/flask.py
+++ b/swagger_ui/handlers/flask.py
@@ -21,9 +21,10 @@ def handler(doc):
         def swagger_blueprint_editor_handler():
             return doc.editor_html
 
-    @swagger_blueprint.route(doc.swagger_json_uri_relative)
-    def swagger_blueprint_config_handler():
-        return jsonify(doc.get_config(request.host))
+    if doc.config_rel_url is None:
+        @swagger_blueprint.route(doc.swagger_json_uri_relative)
+        def swagger_blueprint_config_handler():
+            return jsonify(doc.get_config(request.host))
 
     doc.app.register_blueprint(swagger_blueprint)
 

--- a/swagger_ui/handlers/quart.py
+++ b/swagger_ui/handlers/quart.py
@@ -22,9 +22,10 @@ def handler(doc):
         async def swagger_blueprint_editor_handler():
             return doc.editor_html
 
-    @swagger_blueprint.route(doc.swagger_json_uri_relative, methods=['GET'])
-    async def swagger_blueprint_config_handler():
-        return jsonify(doc.get_config(request.host))
+    if doc.config_rel_url is None:
+        @swagger_blueprint.route(doc.swagger_json_uri_relative, methods=['GET'])
+        async def swagger_blueprint_config_handler():
+            return jsonify(doc.get_config(request.host))
 
     doc.app.register_blueprint(
         blueprint=swagger_blueprint, url_prefix=doc.url_prefix)

--- a/swagger_ui/handlers/sanic.py
+++ b/swagger_ui/handlers/sanic.py
@@ -17,9 +17,10 @@ def handler(doc):
         async def swagger_blueprint_editor_handler(request):
             return response.html(doc.editor_html)
 
-    @swagger_blueprint.get(doc.swagger_json_uri_relative)
-    async def swagger_blueprint_config_handler(request):
-        return response.json(doc.get_config(request.host))
+    if doc.config_rel_url is None:
+        @swagger_blueprint.get(doc.swagger_json_uri_relative)
+        async def swagger_blueprint_config_handler(request):
+            return response.json(doc.get_config(request.host))
 
     swagger_blueprint.static(doc.static_uri_relative, doc.static_dir)
     doc.app.blueprint(swagger_blueprint)

--- a/swagger_ui/handlers/starlette.py
+++ b/swagger_ui/handlers/starlette.py
@@ -31,10 +31,11 @@ def handler(doc):
             ['get'], 'swagger-editor',
         )
 
-    doc.app.router.add_route(
-        doc.swagger_json_uri_absolute, swagger_config_handler,
-        ['get'], 'swagger-config',
-    )
+    if doc.config_rel_url is None:
+        doc.app.router.add_route(
+            doc.swagger_json_uri_absolute, swagger_config_handler,
+            ['get'], 'swagger-config',
+        )
     doc.app.router.mount(
         doc.static_uri_absolute,
         app=StaticFiles(directory='{}/'.format(doc.static_dir)),

--- a/swagger_ui/handlers/tornado.py
+++ b/swagger_ui/handlers/tornado.py
@@ -16,10 +16,12 @@ def handler(doc):
     handlers = [
         (doc.root_uri_absolute(slashes=True), DocHandler),
         (doc.root_uri_absolute(slashes=False), DocHandler),
-        (doc.swagger_json_uri_absolute, ConfigHandler),
         (r'{}/(.+)'.format(doc.static_uri_absolute),
          StaticFileHandler, {'path': doc.static_dir}),
     ]
+
+    if doc.config_rel_url is None:
+        handlers.append((doc.swagger_json_uri_absolute, ConfigHandler))
 
     if doc.editor:
         handlers += [


### PR DESCRIPTION
Added a parameter named `config_rel_url` to `ApplicationDocument` so that it behaves like `config_url` except that it gets the openapi specification from a relative location to the server, example (AioHttp):
```python
from aiohttp import web
from swagger_ui import aiohttp_api_doc

async def handler(req: web.Request) -> web.Response:
    return web.json_response({"openapi":"3.0.1","info":{"title":"python-swagger-ui test api","description":"python-swagger-ui test api","version":"1.0.0"},"servers":[{"url":"http://127.0.0.1:8989/api"}],"tags":[{"name":"default","description":"default tag"}],"paths":{"/hello/world":{"get":{"tags":["default"],"summary":"output hello world.","responses":{"200":{"description":"OK","content":{"application/text":{"schema":{"type":"object","example":"Hello World!!!"}}}}}}}},"components":{}})

app = web.Application()
app.router.add_get("/doc/openapi.json", handler)
aiohttp_api_doc(
    app,
    url_prefix="/doc",
    config_rel_url="/openapi.json",
    editor=True,
)

web.run_app(app, port=8080)
```

The motivation is that populating the "servers" field in the specification at least in aiohttp can't be done before the app is running, so one must inject the current server inside the request (see example below), therefore aiohttp_api_doc could provide a way to confingure a relative url pointing to the specification document in the server.
```python
async def handler(req: web.Request) -> web.Response:
    return web.json_response(
        {
            "openapi": "3.0.1",
            "info": {
                "title": "python-swagger-ui test api",
                "description": "python-swagger-ui test api",
                "version": "1.0.0",
            },
            "servers": [{"url": f"{req.url.scheme}://{req.url.raw_authority}"}], #NOTE: using request to get the server domain
            "tags": [{"name": "default", "description": "default tag"}],
            "paths": {
                "/hello/world": {
                    "get": {
                        "tags": ["default"],
                        "summary": "output hello world.",
                        "responses": {
                            "200": {
                                "description": "OK",
                                "content": {
                                    "application/text": {
                                        "schema": {
                                            "type": "object",
                                            "example": "Hello World!!!",
                                        }
                                    }
                                },
                            }
                        },
                    }
                }
            },
            "components": {},
        }
    )
```