### PR TITLE
Fix get_config to be compatible with openapi spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Project
 tools/*/
 tools/*.tar.gz
+.vscode
+.envrc
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import platform
 from pathlib import Path
 
 from setuptools import find_packages
@@ -7,7 +6,7 @@ from setuptools import setup
 setup(
     name='swagger-ui-py',
     version='23.8.23',
-    python_requires='>3.8.0',
+    python_requires='>3.0.0',
     description=(
         'Swagger UI for Python web framework, '
         'such as Tornado, Flask, Quart, Sanic and Falcon.'

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,13 @@
 import platform
 from pathlib import Path
 
-from packaging.version import Version
 from setuptools import find_packages
 from setuptools import setup
-
-if Version(platform.python_version()) < Version('3.0.0'):
-    raise Exception("`swagger-ui-py` support python version >= 3.0.0 only.")
 
 setup(
     name='swagger-ui-py',
     version='23.8.23',
+    python_requires='>3.8.0',
     description=(
         'Swagger UI for Python web framework, '
         'such as Tornado, Flask, Quart, Sanic and Falcon.'

--- a/swagger_ui/core.py
+++ b/swagger_ui/core.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from jinja2 import Environment
 from jinja2 import FileSystemLoader
 from jinja2 import select_autoescape
-from packaging.version import Version
 
 from swagger_ui.handlers import supported_list
 from swagger_ui.utils import SWAGGER_UI_PY_ROOT
@@ -144,11 +143,7 @@ class ApplicationDocument(object):
         else:
             raise RuntimeError('No config found!')
 
-        version = config.get('openapi', '2.0.0')
-        if Version(version) >= Version('3.0.0'):
-            for server in config.get('servers', []):
-                server['url'] = server['url']
-        elif 'host' not in config:
+        if 'host' not in config:
             config['host'] = host
         return config
 

--- a/swagger_ui/core.py
+++ b/swagger_ui/core.py
@@ -1,6 +1,5 @@
 import copy
 import importlib
-import re
 import urllib.request
 from pathlib import Path
 
@@ -142,12 +141,13 @@ class ApplicationDocument(object):
                 config = _load_config(config_file.read())
         elif self.config_spec:
             config = _load_config(self.config_spec)
+        else:
+            raise RuntimeError('No config found!')
 
         version = config.get('openapi', '2.0.0')
         if Version(version) >= Version('3.0.0'):
             for server in config.get('servers', []):
-                server['url'] = re.sub(r'//[a-z0-9\-\.:]+/?',
-                                       '//{}/'.format(host), server['url'])
+                server['url'] = server['url']
         elif 'host' not in config:
             config['host'] = host
         return config


### PR DESCRIPTION
The regex replacement prevents using the servers directive as specified under: https://learn.openapis.org/specification/servers.html

Requiring `from packaging.version import Version` prevented me from cleanly building this package, and is a non-standard check since setuptools offers `python_requires`. I used minimum 3.8 as set by tox.ini.