### PR TITLE
Allow host injection to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ python3 -c "from swagger_ui import supported_list; print(supported_list)"
   from swagger_ui import falcon_api_doc
   falcon_api_doc(app, config_path='./conf/test.yaml', url_prefix='/api/doc', title='API doc')
   ```
+  Passing a value to the keyword argument `host_inject` will disable the behaviour which injects a host value into the specification served by Swagger UI.
 
 - Edit `Swagger` config file (JSON or YAML)
 

--- a/swagger_ui/core.py
+++ b/swagger_ui/core.py
@@ -143,7 +143,7 @@ class ApplicationDocument(object):
         else:
             raise RuntimeError('No config found!')
 
-        if 'host' not in config:
+        if 'host' not in config and self.extra_config.get('host_inject', True):
             config['host'] = host
         return config
 


### PR DESCRIPTION
There is logic that adds host to the specification that is served by the library. This is problematic for us when the API is behind a load balancer and then a proxy which the library resolves host to `node1`.

This PR allows this logic to be disabled by passing an additional keyword arg called `host_inject`.

We would appreciate it if you could bump the version and publish to PyPI too.