### PR TITLE
Falcon handler: do not use deprecated `resp.body`

### DIFF
--- a/swagger_ui/handlers/falcon.py
+++ b/swagger_ui/handlers/falcon.py
@@ -1,5 +1,3 @@
-import json
-
 from packaging.version import Version
 
 
@@ -16,17 +14,17 @@ class FalconInterface(object):
         class SwaggerDocHandler(Handler):
             def on_get(self, req, resp):
                 resp.content_type = 'text/html'
-                resp.body = doc.doc_html
+                resp.data = doc.doc_html.encode()
 
         class SwaggerEditorHandler(Handler):
             def on_get(self, req, resp):
                 resp.content_type = 'text/html'
-                resp.body = doc.editor_html
+                resp.data = doc.editor_html.encode()
 
         class SwaggerConfigHandler(Handler):
             def on_get(self, req, resp):
                 resp.content_type = 'application/json'
-                resp.body = json.dumps(doc.get_config(f'{req.host}:{req.port}'))
+                resp.media = doc.get_config(f'{req.host}:{req.port}')
 
         suffix = 'async' if self.use_async else None
         doc.app.add_route(doc.root_uri_absolute(slashes=True),


### PR DESCRIPTION
It is a bit tricky to keep supporting Falcon 2.0 (which is 6 year old now), but assuming this is desirable, I changed `resp.body` to `resp.data`, since that already exists in 2.0, and we don't need to branch on version even more.

`resp.body` has been deprecated throughout the 3.0 cycle (more than 3 years), and it is **removed** in [Falcon 4.0](https://falcon.readthedocs.io/en/stable/changes/4.0.0.html#breaking-changes).

Note that `test/falcon_test.py` seems to  require at least Falcon 3.1, so I had to tweak them to verify 2.0 compatibility, but I didn't commit these changes. I did verify it still passed on 2.0 and Python 3.8.