### PR TITLE
Sanitze blueprint name

### DIFF
--- a/swagger_ui/core.py
+++ b/swagger_ui/core.py
@@ -71,7 +71,7 @@ class ApplicationDocument(object):
 
     @property
     def blueprint_name(self):
-        return 'bp{}'.format(self.url_prefix.replace('/', '_'))
+        return 'bp{}'.format(self.url_prefix.replace('/', '_').replace('.', '_'))
 
     @property
     def static_dir(self):


### PR DESCRIPTION
Replaces '.' with '_' since '.' is not an allowed character in the Blueprint name: https://github.com/pallets/flask/blob/2fec0b206c6e83ea813ab26597e15c96fab08be7/src/flask/sansio/blueprints.py#L198